### PR TITLE
Add analyze script to package.json for build analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ The end-to-end tests use [`@next/playwright`](https://nextjs.org/docs/app/guides
 pnpm test:e2e
 ```
 
+## Analyze
+
+Inspect the client and server bundles with Next.js's [built-in Turbopack analyzer](https://nextjs.org/docs/app/guides/package-bundling):
+
+```bash
+pnpm analyze
+```
+
 ## Stack
 
 - **[Next.js 16.3](https://nextjs.org/)**: App Router, Cache Components, Server Functions

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
+    "analyze": "next build && next experimental-analyze",
     "build": "prisma generate && next build",
     "start": "next start",
     "format": "prettier --write .",


### PR DESCRIPTION
Adds a `pnpm analyze` script that runs next build, then next experimental-analyze, so you can inspect client and server bundles with Next’s Turbopack analyzer with updated readme.md


Hope this pr help. If not, close it.