### PR TITLE
Rename runtime prefetching in test names and comments

### DIFF
--- a/components/ui/nav-link.tsx
+++ b/components/ui/nav-link.tsx
@@ -9,7 +9,7 @@ import type { Route } from 'next';
 
 type Props<T extends string = string> = Omit<React.ComponentProps<typeof Link>, 'href' | 'prefetch'> & {
   href: Route<T> | URL;
-  // Defer this link's runtime prefetch until the user hovers/focuses it, rather
+  // Defer this link's URL-specific prefetch until the user hovers/focuses it, rather
   // than firing it eagerly when the link enters the viewport. Use for unbounded
   // lists (e.g. the playlist sidebar) so N links don't each wake a server on load.
   hoverPrefetch?: boolean;

--- a/tests/favorites-page.spec.ts
+++ b/tests/favorites-page.spec.ts
@@ -11,7 +11,7 @@ test.describe('Favorites page (/favorites)', () => {
     });
   });
 
-  test('client navigation shows the runtime-prefetched favorites', async ({ page }) => {
+  test('client navigation shows the favorites resolved at prefetch time', async ({ page }) => {
     await page.goto('/');
     const link = page.locator('aside a[aria-label="Liked Tracks"]').first();
     await link.waitFor({ state: 'visible', timeout: 15000 });

--- a/tests/genre-page.spec.ts
+++ b/tests/genre-page.spec.ts
@@ -15,7 +15,7 @@ test.describe('Genre page (/genre/[genre])', () => {
     });
   });
 
-  test('client navigation shows the runtime-prefetched heading', async ({ page }) => {
+  test('client navigation shows the heading resolved at prefetch time', async ({ page }) => {
     await page.goto('/search');
     const link = page.locator('main a[href^="/genre/"]').first();
     await link.waitFor({ state: 'visible', timeout: 15000 });

--- a/tests/home-page.spec.ts
+++ b/tests/home-page.spec.ts
@@ -11,7 +11,7 @@ test.describe('Home page (/)', () => {
     });
   });
 
-  test('client navigation shows the runtime-prefetched track data', async ({ page }) => {
+  test('client navigation shows the track data resolved at prefetch time', async ({ page }) => {
     await page.goto('/library');
     const link = page.locator('aside a[aria-label="Home"]').first();
     await link.waitFor({ state: 'visible', timeout: 15000 });

--- a/tests/library-page.spec.ts
+++ b/tests/library-page.spec.ts
@@ -11,7 +11,7 @@ test.describe('Library page (/library)', () => {
     });
   });
 
-  test('client navigation shows the runtime-prefetched library grid', async ({ page }) => {
+  test('client navigation shows the library grid resolved at prefetch time', async ({ page }) => {
     await page.goto('/');
     const link = page.locator('aside a[aria-label="Library"]').first();
     await link.waitFor({ state: 'visible', timeout: 15000 });

--- a/tests/playlist-detail.spec.ts
+++ b/tests/playlist-detail.spec.ts
@@ -15,7 +15,7 @@ test.describe('Playlist detail page (/playlist/[id])', () => {
     });
   });
 
-  test('client navigation shows the runtime-prefetched playlist details', async ({ page }) => {
+  test('client navigation shows the playlist details resolved at prefetch time', async ({ page }) => {
     await page.goto('/playlist');
     const link = page.locator('main a[href^="/playlist/"]').first();
     await link.waitFor({ state: 'visible', timeout: 15000 });

--- a/tests/playlist-page.spec.ts
+++ b/tests/playlist-page.spec.ts
@@ -11,7 +11,7 @@ test.describe('Playlists page (/playlist)', () => {
     });
   });
 
-  test('client navigation shows the runtime-prefetched playlist list', async ({ page }) => {
+  test('client navigation shows the playlist list resolved at prefetch time', async ({ page }) => {
     await page.goto('/');
     const link = page.locator('aside a[href="/playlist"]').first();
     await link.waitFor({ state: 'visible', timeout: 15000 });

--- a/tests/search-page.spec.ts
+++ b/tests/search-page.spec.ts
@@ -12,7 +12,7 @@ test.describe('Search page (/search)', () => {
     });
   });
 
-  test('client navigation shows the runtime-prefetched browse grid', async ({ page }) => {
+  test('client navigation shows the browse grid resolved at prefetch time', async ({ page }) => {
     await page.goto('/');
     const link = page.locator('aside a[aria-label="Search"]').first();
     await link.waitFor({ state: 'visible', timeout: 15000 });


### PR DESCRIPTION
`/docs/app/guides/runtime-prefetching` now redirects to [`/docs/app/guides/optimizing-prefetching`](https://nextjs.org/docs/app/guides/optimizing-prefetching), and that guide no longer contains the phrase "runtime prefetch" anywhere.

The README on `main` already uses the current wording ("URL-specific prefetches", no `prefetch = 'allow-runtime'`). These were the leftovers:

- Seven test names read "the runtime-prefetched X". They now read "the X resolved at prefetch time", matching the guide's own section title "Resolve URL data at prefetch time".
- `components/ui/nav-link.tsx` said "this link's runtime prefetch". Now "this link's URL-specific prefetch", matching the README's phrasing.

Names and comments only. No assertions changed, and there is no `allow-runtime` usage in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)